### PR TITLE
League slots

### DIFF
--- a/app/controllers/league_teams_join_controller.rb
+++ b/app/controllers/league_teams_join_controller.rb
@@ -5,12 +5,15 @@ class LeagueTeamsJoinController < ApplicationController
     @team = Team.find(params[:league_teams_join][:team_id])
     @league_team.team = @team
     @league_team.league = @league
-    if @league_team.save!
-      redirect_to league_path(@league), notice: "Your request has been submitted. The owner of #{@league.name} will respond soon."
+    if LeagueTeamsJoin.where(team_id: @team.id, league_id: @league.id) == nil
+      if @league_team.save!
+        redirect_to league_path(@league), notice: "Your request has been submitted. The owner of #{@league.name} will respond soon."
+      else
+        render :new, status: :unprocessable_entity
+      end
     else
-      render :new, status: :unprocessable_entity
+      redirect_to league_path(@league), notice: "You have already sent a request for #{@league.name}. The league owner will respond soon."
     end
-
   end
 
   def update

--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -11,7 +11,7 @@ class LeaguesController < ApplicationController
     tally(@accepted_teams)
     @results.sort_by! { |team_data| [team_data[:points], team_data[:goal_dif], team_data[:goals_for]] }.reverse!
     @slots = @league.number_of_teams - @accepted_joins.count
-    @slots_available = @slots > @league.number_of_teams
+    @slots_available = @slots >= 0
   end
 
   def new

--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -10,6 +10,8 @@ class LeaguesController < ApplicationController
     @accepted_teams = @accepted_joins.map { |join| join.team}
     tally(@accepted_teams)
     @results.sort_by! { |team_data| [team_data[:points], team_data[:goal_dif], team_data[:goals_for]] }.reverse!
+    @slots = @league.number_of_teams - @accepted_joins.count
+    @slots_available = @slots > @league.number_of_teams
   end
 
   def new

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -8,6 +8,7 @@ class TeamsController < ApplicationController
     @team = Team.find(params[:id])
     @player = Player.new
     @accepted_players = @team.players.select { |player| player.accepted == true}
+    @nearby_leagues = nearby_leagues_with_slots(@team)
   end
 
   def new
@@ -45,6 +46,19 @@ class TeamsController < ApplicationController
   end
 
   private
+
+  def nearby_leagues_with_slots(team)
+    nearby_leagues = League.near(team, 15)
+    leagues_with_slots = []
+    nearby_leagues.each do |league|
+      accepted_joins = league.league_teams_joins.select { |join| join.accepted == true}
+      slots = league.number_of_teams - accepted_joins.count
+      if slots > 0
+        leagues_with_slots << league
+      end
+    end
+    return leagues_with_slots
+  end
 
   def team_params
     params.require(:team).permit(:name, :photo, :location)

--- a/app/views/leagues/_table.html.erb
+++ b/app/views/leagues/_table.html.erb
@@ -39,7 +39,9 @@
 <%# LEAGUE TABLE END %>
 
   <%# Button to register for league %>
+<% if @slots_available %>
   <div style="text-align: center;">
+  <h4 style="text-align: center"><%= @slots %> slots available in this league</h4>
     <% if user_signed_in? %>
       <% if !user.teams.empty? && current_user != league.user %>
         <div style="text-align: center col-5">
@@ -65,5 +67,8 @@
       </div>
     </div>
   </div>
+<% else %>
+  <h6 style="text-align: center">This league is full</h6>
+<% end %>
 
 </div>

--- a/app/views/teams/_leagues.html.erb
+++ b/app/views/teams/_leagues.html.erb
@@ -24,7 +24,7 @@
 <div>
   <h3 class="mb-2">Nearby leagues looking for teams</h3>
   <div id="nearby-leagues" class="row">
-    <% League.near(team, 15).each do |league| %>
+    <% nearby_leagues.each do |league| %>
       <div class="card text-bg-success mb-3 mx-3 border-0 p-3" class="custom-card" style="width: 18rem; height: 12rem;" >
         <div class="d-flex justify-content-between">
           <% if league.photo.attached? %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -11,7 +11,7 @@
         <div class="tab-pane fade" id="v-pills-players" role="tabpanel" aria-labelledby="v-pills-players-tab"><%= render partial: "players", locals: {team: @team, player: @player, user: current_user, accepted_players: @accepted_players} %></div>
         <div class="tab-pane fade" id="v-pills-payments" role="tabpanel" aria-labelledby="v-pills-payments-tab">Payments go here</div>
         <div class="tab-pane fade" id="v-pills-fixtures" role="tabpanel" aria-labelledby="v-pills-fixtures-tab">Fixtures go here</div>
-        <div class="tab-pane fade" id="v-pills-leagues" role="tabpanel" aria-labelledby="v-pills-leagues-tab"><%= render partial: "leagues", locals: {team: @team }%></div>
+        <div class="tab-pane fade" id="v-pills-leagues" role="tabpanel" aria-labelledby="v-pills-leagues-tab"><%= render partial: "leagues", locals: {team: @team, nearby_leagues: @nearby_leagues }%></div>
         <div class="tab-pane fade" id="v-pills-statistics" role="tabpanel" aria-labelledby="v-pills-statistics-tab">Statistics go here</div>
         <div class="tab-pane fade" id="v-pills-messages" role="tabpanel" aria-labelledby="v-pills-messages-tab">Messages go here</div>
         <div class="tab-pane fade" id="v-pills-registrations" role="tabpanel" aria-labelledby="v-pills-registrations-tab"><%= render partial: "registrations", locals: { players: @team.players }%></div>


### PR DESCRIPTION
Leagues now calculate the number of free slots on the back-end

If a league has slots available:
- Teams are able to register (and are unable to register more than once)
- There is a counter below the league showing how many slots there are
- The league will appear in the leagues tab of nearby teams

If a league is full
- the league register button will be unavailable