### PR TITLE
Location field checks

### DIFF
--- a/app/views/leagues/_fixtures_generate.html.erb
+++ b/app/views/leagues/_fixtures_generate.html.erb
@@ -3,6 +3,6 @@
     <h5 class="card-title align-items-center d-flex justify-content-center">Generate Fixtures</h5>
     <p class="card-text align-items-center d-flex justify-content-center"><i class="fa-solid fa-plus fa-2xl" style="color: #000000;"></i></p>
     <%# <a href="#" class="stretched-link"></a> %>
-    <%= link_to "", generate_fixtures_path(league), data: {turbo_method: :post, turbo_confirm: "Are you sure you're ready to generate fixtures for this league?"} %>
+    <%= link_to "", generate_fixtures_path(league), data: {turbo_method: :post, turbo_confirm: "Are you sure you're ready to generate fixtures for this league?"}, class:"stretched-link" %>
   </div>
 </div>

--- a/app/views/leagues/_new.html.erb
+++ b/app/views/leagues/_new.html.erb
@@ -11,6 +11,5 @@
               <%= f.input :league_type,:collection => (%w[ 5-aside 6-aside 7-aside])%>
               <%= f.input :number_of_teams %>
               <%= f.input :days_per_week %>
-              <%= f.input :location %>
               <%= f.button :submit, "create league", class:"btn btn-primary" %>
             <% end %>


### PR DESCRIPTION
Removed duplicate Location field in League creation form
Location field works fine in Team creation - may be a Heroku gem issue?

Tried to restyle the autocomplete form but couldn't for now...